### PR TITLE
worker.py: Avoid letting a job get stuck if exception occurs

### DIFF
--- a/spark/worker.py
+++ b/spark/worker.py
@@ -109,7 +109,7 @@ class Worker:
                     import traceback
 
                     tb = traceback.format_exc()
-                    log.write(tb)
+                    jlog.write(tb)
                     self._conn.send_job_status(job_id, JobStatus.REJECTED)
                     log.warning(tb)
                     log.info('Rejected job {}'.format(job_id))
@@ -206,7 +206,7 @@ class Worker:
             import traceback
 
             tb = traceback.format_exc()
-            jlog.write(tb)
+            log.info(tb)
             self._conn.send_job_status(job_id, JobStatus.REJECTED)
             log.warning(tb)
             log.info('Rejected job {} due to exception'.format(job_id))


### PR DESCRIPTION
Some instances of stuck jobs were observed recently for PureOS.  From the logs, I think a Python exception may have occurred after the build completed but before the artifacts were uploaded.  I can't tell what might have caused that exception, if it did occur.

This change would ensure that a 'rejected' status is sent if this occurs, rather than leaving the job stuck with no result.

I applied this change to fennel.pureos.net (the new worker) to try to identify what was causing the stuck jobs, but this never happened again.  No jobs got stuck after that and this exception code was never hit, so I can't identify the root cause.